### PR TITLE
[fix] user 엔티티 및 로직 수정, AuthServiceImpl SecretKey 타입 수정

### DIFF
--- a/src/main/java/com/server/delivery/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/server/delivery/domain/auth/service/AuthServiceImpl.java
@@ -32,14 +32,15 @@ import java.util.Date;
 public class AuthServiceImpl implements AuthService {
 
     private static final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-    @Value("${jwt.secret.key}")
-    private static String secretKey;
     private final S3ImageUtilImpl s3ImageUtilImpl;
     private final UserJpaRepository userRepository;
     private final UserHelper userHelper;
+    // Change this to a non-static field
+    @Value("${jwt.secret.key}")
+    private String secretKey;
 
     // JWT 토큰 생성 정적 메서드
-    private static String generateToken(User user) {
+    private static String generateToken(User user, String secretKey) {
         return Jwts.builder()
                 .setSubject(user.getUsername())
                 .claim("id", user.getId())
@@ -47,11 +48,11 @@ public class AuthServiceImpl implements AuthService {
                 .claim("tokenIssuedAt", LocalDateTime.now().toString())
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // 1시간 만료
-                .signWith(getSigningKey())
+                .signWith(getSigningKey(secretKey))
                 .compact();
     }
 
-    private static SecretKey getSigningKey() {
+    private static SecretKey getSigningKey(String secretKey) {
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         return Keys.hmacShaKeyFor(keyBytes);
     }
@@ -69,7 +70,6 @@ public class AuthServiceImpl implements AuthService {
         User user = CustomerCreateRequestDto.from(signUpRequestDto, uploadedImage);
 
         userRepository.save(user);
-
     }
 
     @Transactional
@@ -84,7 +84,6 @@ public class AuthServiceImpl implements AuthService {
         User user = OwnerCreateRequestDto.from(requestDto, uploadedImage);
 
         userRepository.save(user);
-
     }
 
     @Transactional
@@ -94,7 +93,7 @@ public class AuthServiceImpl implements AuthService {
 
         if (passwordEncoder.matches(signInRequestDto.getPassword(), user.getPassword())) {
             user.updateTokenIssuedAt();
-            return generateToken(user);
+            return generateToken(user, secretKey);
         } else {
             throw new CustomUserException(ExceptionCode.BAD_REQUEST);
         }
@@ -104,7 +103,7 @@ public class AuthServiceImpl implements AuthService {
     public String renewToken(CustomUserDetail customUserDetail) {
         User user = userHelper.getUser(customUserDetail.getUsername());
 
-        String renewToken = generateToken(user);
+        String renewToken = generateToken(user, secretKey);
         user.updateTokenIssuedAt();
 
         return renewToken;

--- a/src/main/java/com/server/delivery/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/server/delivery/domain/user/service/UserServiceImpl.java
@@ -51,6 +51,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public UserResponseDto findUserById(Long userId, CustomUserDetail customUserDetail) {
         //유저 검증
         userHelper.validateUser(customUserDetail.getUsername());

--- a/src/main/java/com/server/delivery/model/user/entity/User.java
+++ b/src/main/java/com/server/delivery/model/user/entity/User.java
@@ -18,8 +18,8 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE p_user SET deleted = true WHERE user_id = ?")
-@SQLRestriction("deleted = false")
+@SQLDelete(sql = "UPDATE p_user SET user_deleted = true WHERE user_id = ?")
+@SQLRestriction("user_deleted = false")
 @Table(name = "p_user")
 public class User extends BaseEntity {
 
@@ -70,6 +70,9 @@ public class User extends BaseEntity {
 
     @Column(name = "user_token_issued_at")
     private LocalDateTime tokenIssuedAt;
+
+    @Column(name = "user_deleted")
+    private Boolean deleted;
 
     public void updateTokenIssuedAt() {
         this.tokenIssuedAt = LocalDateTime.now();

--- a/src/main/java/com/server/delivery/model/user/entity/User.java
+++ b/src/main/java/com/server/delivery/model/user/entity/User.java
@@ -72,7 +72,8 @@ public class User extends BaseEntity {
     private LocalDateTime tokenIssuedAt;
 
     @Column(name = "user_deleted")
-    private Boolean deleted;
+    @Builder.Default
+    private Boolean deleted = Boolean.FALSE;
 
     public void updateTokenIssuedAt() {
         this.tokenIssuedAt = LocalDateTime.now();


### PR DESCRIPTION
## #️연관된 이슈

> ex) #이슈번호, #이슈번호

## 작업 내용

1. Entity의 SoftDelete 컬럼 deleted 추가
2. SQLRestriction 쿼리 수정
3. findUserById메서드 Transactional(readOnly= true) 추가
4. AuthServiceImpl의 secretKey가 static에서 인식되지 않는 문제 해결

