### PR TITLE
[Refactor] 응답 객체 생성, CustomUserDetail 메서드명 수정(uuid -> id)

### DIFF
--- a/src/main/java/com/server/delivery/common/jwt/CustomUserDetail.java
+++ b/src/main/java/com/server/delivery/common/jwt/CustomUserDetail.java
@@ -21,7 +21,7 @@ public class CustomUserDetail implements UserDetails {
         this.authorities = authorities;
     }
 
-    public Long getUuid() {
+    public Long getId() {
         return userId;
     }
 

--- a/src/main/java/com/server/delivery/common/response/CustomResponse.java
+++ b/src/main/java/com/server/delivery/common/response/CustomResponse.java
@@ -1,0 +1,29 @@
+package com.server.delivery.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class CustomResponse<T> {
+    private int status;
+    private String message;
+    private T body;
+
+    public static <T> CustomResponse<T> success(String message, T data) {
+        return (CustomResponse<T>) CustomResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message(message)
+                .body(data)
+                .build();
+    }
+
+    public static <T> CustomResponse<T> success(String message) {
+        return (CustomResponse<T>) CustomResponse.builder()
+                .status(HttpStatus.OK.value())
+                .message(message)
+                .body(null)
+                .build();
+    }
+}


### PR DESCRIPTION
## #️연관된 이슈

#13 

## 작업 내용

이전에 개발하지 못했던 응답 객체 생성입니다!
body를 매개변수로 담는 메서드와 메세지만 담는 메서드 두 개로 만들었습니다.

```
 public static <T> CustomResponse<T> success(String message, T data) {
        return (CustomResponse<T>) CustomResponse.builder()
                .status(HttpStatus.OK.value())
                .message(message)
                .body(data)
                .build();
    }

    public static <T> CustomResponse<T> success(String message) {
        return (CustomResponse<T>) CustomResponse.builder()
                .status(HttpStatus.OK.value())
                .message(message)
                .body(null)
                .build();
    }

```
